### PR TITLE
Added a showSearch parameter to PagefindSearch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagefind-vue",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "./dist/pagefind-vue.umd.js",
   "module": "./dist/pagefind-vue.es.js",

--- a/src/Home.vue
+++ b/src/Home.vue
@@ -6,10 +6,9 @@
     <div>
         <router-link to="/index2">Index 2</router-link>
     </div>
-    <p>Example index with a custom default sort ordering</p>
+    <p>Example index with a custom default sort ordering and a hidden search bar</p>
 </template>
-  
+
 export default {
     name: 'Home'
 };
-  

--- a/src/Index2.vue
+++ b/src/Index2.vue
@@ -5,6 +5,7 @@
     :pagefind="pagefind"
     :default-sort-function="customDefaultSort"
     :result-sort="alphaSort"
+    :show-search="false"
   >
   </Search>
 </template>

--- a/src/components/PagefindSearch.vue
+++ b/src/components/PagefindSearch.vue
@@ -1,7 +1,7 @@
 <!-- This is named "PagefindSearch" because it Vue convention to not have single-word components. It is exported and consumed as `Search`, however. -->
 <template>
   <div class="search-container">
-    <section class="border-bottom fade-section" :class="{ visible: mounted }">
+    <section v-if="showSearch" class="border-bottom fade-section" :class="{ visible: mounted }">
       <form class="search-form" @submit.prevent="performSearch(searchQuery)">
         <div class="input-wrapper">
           <label for="search" class="visually-hidden">Search</label>
@@ -56,20 +56,23 @@ import Filters from './SearchFilters.vue'
 import Results from './SearchResults.vue'
 import type { FiltersDefinition, Filter, ResultData, SortOption } from './types'
 
-const props = defineProps<{
-  pagefind: any
-  itemsPerPage?: number
-  filtersDefinition?: FiltersDefinition
-  tabbedFilter?: string
-  defaultTab?: string
-  excludeFilters?: string[]
-  excludeFilterOptions?: Record<string, string[]>
-  checkboxToDropdownBreakpoint?: number
-  customSortFunctions?: Record<string, (a: any, b: any) => number>
-  defaultSortFunction?: (a: [string, number], b: [string, number]) => number
-  filterGroupSortFunction?: (a: string, b: string, filters: Filter) => number
-  resultSort?: SortOption
-}>()
+const props = withDefaults(defineProps<{
+  pagefind: any;
+  itemsPerPage?: number;
+  filtersDefinition?: FiltersDefinition;
+  tabbedFilter?: string;
+  defaultTab?: string;
+  excludeFilters?: string[];
+  excludeFilterOptions?: Record<string, string[]>;
+  checkboxToDropdownBreakpoint?: number;
+  customSortFunctions?: Record<string, (a: any, b: any) => number>;
+  defaultSortFunction?: (a: [string, number], b: [string, number]) => number;
+  filterGroupSortFunction?: (a: string, b: string, filters: Filter) => number;
+  resultSort?: SortOption;
+  showSearch?: boolean;
+}>(), {
+  showSearch: true,
+});
 
 const searchQuery = ref('')
 const results = ref<any[]>([]) // raw search results
@@ -82,6 +85,7 @@ const currentPage = ref(1)
 const totalResults = ref(0)
 const activeTab = ref('')
 const selectedFilters = ref<{ [key: string]: string[] }>({})
+const showSearch = props.showSearch
 
 const validFilterKeys = computed(() => {
   // Any filters not returned from this should not be sent to Pagefind

--- a/src/components/__tests__/ShowSearchParameter.spec.ts
+++ b/src/components/__tests__/ShowSearchParameter.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import PagefindSearch from '../PagefindSearch.vue'
+
+const mockPagefind = {
+  search: vi.fn().mockResolvedValue({
+    total: 0,
+  }),
+  filters: vi.fn().mockResolvedValue({}),
+}
+
+describe('PagefindSearch show search parameter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should show or hide the search field as appropriate', async () => {
+    mockPagefind.search.mockClear()
+
+    //check that the search field is hidden when showSearch is false
+    const wrapper = mount(PagefindSearch, {
+      props: {
+        pagefind: mockPagefind,
+        showSearch: false,
+      },
+      global: {
+        stubs: {
+          Filters: true,
+          Results: true,
+          Tabs: true,
+        },
+      },
+    })
+
+    await nextTick()
+
+    expect(wrapper.find('.search-form').exists()).toBe(false)
+
+    mockPagefind.search.mockClear()
+
+    //check that the search field is shown when showSearch is true
+    const wrapperDefault = mount(PagefindSearch, {
+      props: {
+        pagefind: mockPagefind,
+        showSearch: true,
+      },
+      global: {
+        stubs: {
+          Filters: true,
+          Results: true,
+          Tabs: true,
+        },
+      },
+    })
+
+    await nextTick()
+
+    expect(wrapperDefault.find('.search-form').exists()).toBe(true)
+
+    //check that the search field is shown when no parameter is given
+    const wrapperNoParam = mount(PagefindSearch, {
+      props: {
+        pagefind: mockPagefind,
+      },
+      global: {
+        stubs: {
+          Filters: true,
+          Results: true,
+          Tabs: true,
+        },
+      },
+    })
+
+    await nextTick()
+
+    expect(wrapperNoParam.find('.search-form').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Change Summary

This PR adds a showSearch parameter to PagefindSearch to allow the user to hide the search bar

## Related issue number

Unblocks DAR-1017

## PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Refactor/optimization
- [ ] Test Coverage
- [ ] Documentation
- [ ] Revert
- [ ] Release

## Engineer Checklist
<!-- Try not to request a review from anyone else if your build is not passing green, unless you have a particular reason, there are blockers, or it's a WIP PR. A red pipeline is a review in itself. -->
<!-- You can cross-out any irrelevant checkboxes with the markdown ~strikethrough syntax~. -->

- [x] The PR title is clear and descriptive.
- [x] Satisfied all pre-commit hooks locally, manually tested the changes and investigated potential regressions.
- [x] Have checked files to be committed to ensure no sensitive information or unwanted files are included.
- [x] Added or modified tests that cover the codebase changes made in this diff.
- [ ] All automated checks and tests pass during CI.
- [ ] Documentation and code comments have been added (where applicable).
- [ ] Any hacks or questionable design decisions have been highlighted in the code and in the PR.
- [ ] Does the PR require any infrastructure changes before deployment? Detail them below if so.
- [ ] Are there any other outstanding blockers or pre-requisites that must be satisfied elsewhere in order for this work to be released?
- [ ] If this is a feature PR, add this PR to the summary of the `Dev -> Prod` PR or open that PR if necessary. This helps us track the contents of production deploys.
- [ ] Are there any other required post-deployment actions? If so, detail them below **_AND_** on a `develop` to `main` PR.


### Infrastructure Changes (Optional)

<!-- Please give a short summary of the necessary infrastructure. Link to any relevant GH or Jira tickets. -->

### Blockers (Optional)

### Post Deployment Actions (Optional)

<!-- Include any post-deployment actions such as Django management commands.
If this is a `develop` to `main` PR, individual feature branch authors need to
copy their notes from the individual PR here. -->
