### PR TITLE
Fallback to relevance sorting during keyword search

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,18 +199,25 @@ const alphabeticalSortOrder = { title: 'desc' }
 </script>
 ```
 
-### Keyword Search and Sorting
+The resultSort object can be changed dynamically when the keyword changes using a handler for the emitted event `onQueryChange`, as below:
 
-By default, results are sorted in descending order of relevance when a keyword search is performed. To disable this and continue sorting by the provided result sorting order.
+```vue
+<Search :resultSort="resultSort" @update:searchQuery="onQueryChange">
+  </Search>
 
-This can be disabled by passing a value of false in the property `sort-by-relevance-with-keyword` when instantiating a Search component as below.
+<script>
+const defaultSort: SortOption = { classification: 'asc' }
+let resultSort = ref<SortOption>(defaultSort)
 
-````vue
-<Search
-  ...
-  :sort-by-relevance-with-keyword=false>
-  ...
-</Search>
+function onQueryChange(newQuery: string) {
+  if (newQuery && newQuery.length > 0) {
+    resultSort.value = { relevance: 'desc' }
+  } else if (!newQuery) {
+    resultSort.value = defaultSort
+  }
+}
+</script>
+```
 
 ## Hiding the Search Bar
 
@@ -222,7 +229,7 @@ If you want to hide the keyword search bar, you can pass a `showKeywordInput` pa
   :=":showKeywordInput="false"">
   ...
 </Search>
-````
+```
 
 ## Recommended IDE Setup
 

--- a/README.md
+++ b/README.md
@@ -190,16 +190,27 @@ const excludedOptions = {
 To provide a sort ordering, pass an object whose key(s) are sort names as defined by `data-pagefind-sort` and values are either `asc` or `desc` for ascending or descending sorting order.
 
 ```vue
-<Search
-  ...
-  :=":result-sort="alphabeticalSortOrder"">
+<Search ... :result-sort="alphabeticalSortOrder">
   ...
 </Search>
 
 <script>
-const alphabeticalSortOrder = {title: "desc"}
+const alphabeticalSortOrder = { title: 'desc' }
 </script>
 ```
+
+### Keyword Search and Sorting
+
+By default, results are sorted in descending order of relevance when a keyword search is performed. To disable this and continue sorting by the provided result sorting order.
+
+This can be disabled by passing a value of false in the property `sort-by-relevance-with-keyword` when instantiating a Search component as below.
+
+````vue
+<Search
+  ...
+  :sort-by-relevance-with-keyword=false>
+  ...
+</Search>
 
 ## Hiding the Search Bar
 
@@ -211,7 +222,7 @@ If you want to hide the keyword search bar, you can pass a `showKeywordInput` pa
   :=":showKeywordInput="false"">
   ...
 </Search>
-```
+````
 
 ## Recommended IDE Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pagefind-vue",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pagefind-vue",
-      "version": "0.0.5",
+      "version": "0.0.7",
       "dependencies": {
         "vue": "^3.5.13"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagefind-vue",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "main": "./dist/pagefind-vue.umd.js",
   "module": "./dist/pagefind-vue.es.js",
@@ -35,7 +35,6 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
-    "vue-router": "^4.5.0",
     "@playwright/test": "^1.49.1",
     "@tsconfig/node22": "^22.0.0",
     "@types/jsdom": "^21.1.7",
@@ -57,6 +56,7 @@
     "vite": "^6.0.5",
     "vite-plugin-vue-devtools": "^7.6.8",
     "vitest": "^2.1.8",
+    "vue-router": "^4.5.0",
     "vue-tsc": "^2.1.10"
   }
 }

--- a/src/Index1.vue
+++ b/src/Index1.vue
@@ -144,7 +144,7 @@ function customDefaultSort(a: [string, number], b: [string, number]): number {
 }
 
 function onQueryChange(newQuery: string) {
-  if (newQuery && newQuery.length > 0 && resultSort.value.relevance !== 'desc') {
+  if (newQuery && newQuery.length > 0) {
     resultSort.value = { relevance: 'desc' }
   } else if (!newQuery) {
     resultSort.value = defaultSort

--- a/src/Index1.vue
+++ b/src/Index1.vue
@@ -11,6 +11,8 @@
     :exclude-filter-options="excludOptions"
     :filter-group-sort-function="sortFilterGroupsByList"
     :filters-definition="filtersDefinition"
+    :resultSort="resultSort"
+    @update:searchQuery="onQueryChange"
   >
   </Search>
 </template>
@@ -23,6 +25,7 @@ import type {
   CustomSortFunctions,
   FiltersDefinition,
   Filter,
+  SortOption,
 } from './components/types'
 
 let pagefindPath: string
@@ -31,6 +34,9 @@ if (import.meta.env.PROD) {
 } else {
   pagefindPath = '../../fixtures/pagefind/pagefind.js' // this needs to be the path relative from the file it is actually imported
 }
+
+const defaultSort: SortOption = { classification: 'asc' }
+let resultSort = ref<SortOption>(defaultSort)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const pagefind = ref<any>(null)
@@ -135,6 +141,14 @@ const customSortFunctions: CustomSortFunctions = {
 function customDefaultSort(a: [string, number], b: [string, number]): number {
   // Sort by facet count ascending (internal default is descending)
   return b[1] - a[1]
+}
+
+function onQueryChange(newQuery: string) {
+  if (newQuery && newQuery.length > 0 && resultSort.value.relevance !== 'desc') {
+    resultSort.value = { relevance: 'desc' }
+  } else if (!newQuery) {
+    resultSort.value = defaultSort
+  }
 }
 </script>
 

--- a/src/components/PagefindSearch.vue
+++ b/src/components/PagefindSearch.vue
@@ -101,6 +101,8 @@ const selectedFilters = ref<{ [key: string]: string[] }>({})
 const tabFilters = ref<{ [tabValue: string]: { [key: string]: string[] } }>({})
 const showKeywordInput = props.showKeywordInput
 
+const emit = defineEmits(['update:searchQuery'])
+
 const validFilterKeys = computed(() => {
   // Any filters not returned from this should not be sent to Pagefind
   return filters.value
@@ -282,6 +284,8 @@ const sortedFilterGroups = computed(() => {
 
 watch(searchQuery, async (newQuery) => {
   currentPage.value = 1 // reset to first page on new search
+  emit('update:searchQuery', newQuery)
+  await nextTick() // wait for any changes to sort type, etc before searching
   await performSearch(newQuery || null)
 })
 
@@ -461,11 +465,7 @@ async function performSearch(query: string | null) {
   try {
     const searchFilters = getSearchFilters()
 
-    // override any provided resultSort with relevance (descending) if using keyword search
     let desiredSort = props.resultSort || { classification: 'asc' }
-    if (props.sortByRelevanceWithKeyword && query) {
-      desiredSort = { relevance: 'desc' }
-    }
 
     // Sync URL before performing search
     updateUrlParams(currentPage.value)

--- a/src/components/PagefindSearch.vue
+++ b/src/components/PagefindSearch.vue
@@ -76,11 +76,13 @@ const props = withDefaults(
     resultSort?: SortOption
     showKeywordInput?: boolean
     checkboxFilterThreshold?: number
+    useRelevanceWithKeyword?: boolean
   }>(),
   {
     showKeywordInput: true,
     itemsPerPage: 10,
     checkboxFilterThreshold: 8,
+    useRelevanceWithKeyword: true,
   },
 )
 
@@ -459,13 +461,19 @@ async function performSearch(query: string | null) {
   try {
     const searchFilters = getSearchFilters()
 
+    // override any provided resultSort with relevance (descending) if using keyword search
+    let desiredSort = props.resultSort || { classification: 'asc' }
+    if (props.useRelevanceWithKeyword && query) {
+      desiredSort = { relevance: 'desc' }
+    }
+
     // Sync URL before performing search
     updateUrlParams(currentPage.value)
 
     // Perform main search with all filters
     const searchResults = await props.pagefind
       .search(query || null, {
-        sort: props.resultSort || { classification: 'asc' },
+        sort: desiredSort,
         filters: searchFilters,
       })
       .catch((error: Error) => {

--- a/src/components/PagefindSearch.vue
+++ b/src/components/PagefindSearch.vue
@@ -76,13 +76,13 @@ const props = withDefaults(
     resultSort?: SortOption
     showKeywordInput?: boolean
     checkboxFilterThreshold?: number
-    useRelevanceWithKeyword?: boolean
+    sortByRelevanceWithKeyword?: boolean
   }>(),
   {
     showKeywordInput: true,
     itemsPerPage: 10,
     checkboxFilterThreshold: 8,
-    useRelevanceWithKeyword: true,
+    sortByRelevanceWithKeyword: true,
   },
 )
 
@@ -463,7 +463,7 @@ async function performSearch(query: string | null) {
 
     // override any provided resultSort with relevance (descending) if using keyword search
     let desiredSort = props.resultSort || { classification: 'asc' }
-    if (props.useRelevanceWithKeyword && query) {
+    if (props.sortByRelevanceWithKeyword && query) {
       desiredSort = { relevance: 'desc' }
     }
 

--- a/src/components/PagefindSearch.vue
+++ b/src/components/PagefindSearch.vue
@@ -82,7 +82,6 @@ const props = withDefaults(
     showKeywordInput: true,
     itemsPerPage: 10,
     checkboxFilterThreshold: 8,
-    sortByRelevanceWithKeyword: true,
   },
 )
 

--- a/src/components/__tests__/ResultSortParameter.spec.ts
+++ b/src/components/__tests__/ResultSortParameter.spec.ts
@@ -37,11 +37,9 @@ describe('PagefindSearch result sort parameter', () => {
     await nextTick()
 
     const vm = wrapper.vm as any
-    await vm.performSearch('test query')
+    await vm.performSearch()
 
-    //
     expect(mockPagefind.search).toHaveBeenCalledWith(
-      'test query',
       expect.objectContaining({
         sort: customResultSort,
       }),
@@ -69,11 +67,11 @@ describe('PagefindSearch result sort parameter', () => {
     const vmDefault = wrapperDefault.vm as any
     await vmDefault.performSearch('test query')
 
-    // Search should be called with default sort
+    // Search should be called with relevance sort
     expect(mockPagefind.search).toHaveBeenCalledWith(
       'test query',
       expect.objectContaining({
-        sort: { classification: 'asc' }, // this is currently the default in the component
+        sort: { relevance: 'desc' },
       }),
     )
   })

--- a/src/components/__tests__/ResultSortParameter.spec.ts
+++ b/src/components/__tests__/ResultSortParameter.spec.ts
@@ -15,7 +15,7 @@ describe('PagefindSearch result sort parameter', () => {
     vi.clearAllMocks()
   })
 
-  it('should apply resultSort when provided to search function', async () => {
+  it('should apply resultSort when provided to search function only without keyword', async () => {
     mockPagefind.search.mockClear()
 
     const customResultSort = { Date: 'asc' as 'asc' }
@@ -40,6 +40,7 @@ describe('PagefindSearch result sort parameter', () => {
     await vm.performSearch()
 
     expect(mockPagefind.search).toHaveBeenCalledWith(
+      null, // no query now
       expect.objectContaining({
         sort: customResultSort,
       }),
@@ -67,7 +68,7 @@ describe('PagefindSearch result sort parameter', () => {
     const vmDefault = wrapperDefault.vm as any
     await vmDefault.performSearch('test query')
 
-    // Search should be called with relevance sort
+    // Search should be called with relevance sort during keyword search
     expect(mockPagefind.search).toHaveBeenCalledWith(
       'test query',
       expect.objectContaining({

--- a/src/components/__tests__/ResultSortParameter.spec.ts
+++ b/src/components/__tests__/ResultSortParameter.spec.ts
@@ -72,7 +72,7 @@ describe('PagefindSearch result sort parameter', () => {
     expect(mockPagefind.search).toHaveBeenCalledWith(
       'test query',
       expect.objectContaining({
-        sort: { relevance: 'desc' },
+        sort: { classification: 'asc' },
       }),
     )
   })


### PR DESCRIPTION
## Change Summary

This PR changes the default result sorting when keyword search is being performed to sorting in descending order of relevance.

## Related issue number

Required work for Tsumeb search ordering (See DAR-1040)

## PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Refactor/optimization
- [ ] Test Coverage
- [ ] Documentation
- [ ] Revert
- [ ] Release

## Engineer Checklist
<!-- Try not to request a review from anyone else if your build is not passing green, unless you have a particular reason, there are blockers, or it's a WIP PR. A red pipeline is a review in itself. -->
<!-- You can cross-out any irrelevant checkboxes with the markdown ~strikethrough syntax~. -->

- [x] The PR title is clear and descriptive.
- [x] Satisfied all pre-commit hooks locally, manually tested the changes and investigated potential regressions.
- [x] Have checked files to be committed to ensure no sensitive information or unwanted files are included.
- [ ] Added or modified tests that cover the codebase changes made in this diff.
- [ ] All automated checks and tests pass during CI.
- [x] Documentation and code comments have been added (where applicable).
- [ ] Any hacks or questionable design decisions have been highlighted in the code and in the PR.
- [ ] Does the PR require any infrastructure changes before deployment? Detail them below if so.
- [ ] Are there any other outstanding blockers or pre-requisites that must be satisfied elsewhere in order for this work to be released?
- [ ] If this is a feature PR, add this PR to the summary of the `Dev -> Prod` PR or open that PR if necessary. This helps us track the contents of production deploys.
- [ ] Are there any other required post-deployment actions? If so, detail them below **_AND_** on a `develop` to `main` PR.


### Infrastructure Changes (Optional)

<!-- Please give a short summary of the necessary infrastructure. Link to any relevant GH or Jira tickets. -->

### Blockers (Optional)

### Post Deployment Actions (Optional)

<!-- Include any post-deployment actions such as Django management commands.
If this is a `develop` to `main` PR, individual feature branch authors need to
copy their notes from the individual PR here. -->
