### PR TITLE
Fixed current page not updating in PagefindSearch

### DIFF
--- a/src/components/PagefindSearch.vue
+++ b/src/components/PagefindSearch.vue
@@ -45,6 +45,7 @@
         :total-results="totalResults"
         @update-url-params="updateUrlParams"
         @perform-search="performSearch"
+        @update-page="handlePageChange"
       >
         <template #result="{ result }">
           <slot name="result" :result="result" />
@@ -346,6 +347,10 @@ const updateUrlParams = (page: number) => {
   })
 
   window.history.replaceState({}, '', url)
+}
+
+function handlePageChange(page: number) {
+  currentPage.value = page
 }
 
 async function updateCurrentPageResults() {

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -57,7 +57,7 @@ const props = defineProps({
   totalResults: Number,
 })
 
-const emit = defineEmits(['update-url-params', 'perform-search'])
+const emit = defineEmits(['update-page', 'update-url-params', 'perform-search'])
 
 const componentCurrentPage = ref<number>(props.currentPage || 1)
 const componentPageResults = ref<(ResultData | null)[]>(props.pageResults)
@@ -108,6 +108,7 @@ watch(
 
 const handlePageChange = (page: number) => {
   componentCurrentPage.value = page
+  emit('update-page', page)
   emit('update-url-params', page)
   updateCurrentPageResults()
 }

--- a/src/components/__tests__/PageNumber.spec.ts
+++ b/src/components/__tests__/PageNumber.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
-import Search from '../PagefindSearch.vue' // update with your correct path
+import Search from '../PagefindSearch.vue'
 
 function makePagefindMock(total = 25) {
   return {

--- a/src/components/__tests__/PageNumber.spec.ts
+++ b/src/components/__tests__/PageNumber.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import Search from '../PagefindSearch.vue' // update with your correct path
+
+function makePagefindMock(total = 25) {
+  return {
+    search: async (_query: any, _opts: any) => {
+      const results = Array.from({ length: total }, (_, i) => ({
+        data: async () => ({
+          id: i + 1,
+          title: `Result #${i + 1}`,
+          meta: {
+            title: `Result #${i + 1}`,
+          },
+        }),
+      }))
+      return {
+        results,
+        total,
+      }
+    },
+    filters: async () => ({}),
+  }
+}
+
+describe('Search pagination', () => {
+  it('updates the current page when Next and Previous buttons are clicked', async () => {
+    const wrapper = mount(Search, {
+      props: {
+        pagefind: makePagefindMock(25),
+        itemsPerPage: 10,
+      },
+      attachTo: document.body
+    })
+    await flushPromises()
+
+    const buttons = wrapper.findAll('button')
+    const nextButton = buttons.find(btn => btn.text() === 'Next')
+    const prevButton = buttons.find(btn => btn.text() === 'Previous')
+
+    let resultEls = wrapper.findAll('li')
+    let resultTexts = resultEls.map(el => el.text())
+    console.log(resultTexts)
+    expect(resultTexts).toEqual(
+      Array.from({length: 10}, (_, i) => `Result #${i+1}`)
+    );
+
+    await nextButton!.trigger('click')
+    await flushPromises();
+    resultEls = wrapper.findAll('li')
+    resultTexts = resultEls.map(el => el.text())
+    console.log(resultTexts)
+
+    expect(resultTexts).toEqual(
+      Array.from({length: 10}, (_, i) => `Result #${i+11}`)
+    );
+
+
+    await nextButton!.trigger('click')
+    await flushPromises();
+    resultEls = wrapper.findAll('li')
+    resultTexts = resultEls.map(el => el.text())
+    console.log(resultTexts)
+
+    expect(resultTexts).toEqual(
+      Array.from({length: 5}, (_, i) => `Result #${i+21}`)
+    );
+
+    //going back from 3 shouldn't take you directly to one
+    await prevButton!.trigger('click')
+    await flushPromises();
+    resultEls = wrapper.findAll('li')
+    resultTexts = resultEls.map(el => el.text())
+    console.log(resultTexts)
+
+    expect(resultTexts).toEqual(
+      Array.from({length: 10}, (_, i) => `Result #${i+11}`)
+    );
+  })
+})

--- a/src/components/__tests__/PageNumber.spec.ts
+++ b/src/components/__tests__/PageNumber.spec.ts
@@ -40,7 +40,6 @@ describe('Search pagination', () => {
 
     let resultEls = wrapper.findAll('li')
     let resultTexts = resultEls.map(el => el.text())
-    console.log(resultTexts)
     expect(resultTexts).toEqual(
       Array.from({length: 10}, (_, i) => `Result #${i+1}`)
     );
@@ -49,7 +48,6 @@ describe('Search pagination', () => {
     await flushPromises();
     resultEls = wrapper.findAll('li')
     resultTexts = resultEls.map(el => el.text())
-    console.log(resultTexts)
 
     expect(resultTexts).toEqual(
       Array.from({length: 10}, (_, i) => `Result #${i+11}`)
@@ -60,7 +58,6 @@ describe('Search pagination', () => {
     await flushPromises();
     resultEls = wrapper.findAll('li')
     resultTexts = resultEls.map(el => el.text())
-    console.log(resultTexts)
 
     expect(resultTexts).toEqual(
       Array.from({length: 5}, (_, i) => `Result #${i+21}`)
@@ -71,7 +68,6 @@ describe('Search pagination', () => {
     await flushPromises();
     resultEls = wrapper.findAll('li')
     resultTexts = resultEls.map(el => el.text())
-    console.log(resultTexts)
 
     expect(resultTexts).toEqual(
       Array.from({length: 10}, (_, i) => `Result #${i+11}`)


### PR DESCRIPTION
## Change Summary

This PR fixes a bug Tracy found in Tsumeb where highlighting text in the search caused the search results to reset to page 1. This bug also caused the "previous page" button to go back to page 1, regardless of which page the user was on.

Fundamentally the issues was that the pagination and search results components were updating their internal page number state, but the PagefindSearch component wasn't.

To see that this works, go to the `index1` demo page and see that the next and previous pages perform as expected, and compare to the main branch to see the bugged behavior.

## Related issue number

Will fix DAR-1246 once used in Tsumeb

## PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Refactor/optimization
- [ ] Test Coverage
- [ ] Documentation
- [ ] Revert
- [ ] Release

## Engineer Checklist
<!-- Try not to request a review from anyone else if your build is not passing green, unless you have a particular reason, there are blockers, or it's a WIP PR. A red pipeline is a review in itself. -->
<!-- You can cross-out any irrelevant checkboxes with the markdown ~strikethrough syntax~. -->

- [x] The PR title is clear and descriptive.
- [x] Satisfied all pre-commit hooks locally, manually tested the changes and investigated potential regressions.
- [x] Have checked files to be committed to ensure no sensitive information or unwanted files are included.
- [x] Added or modified tests that cover the codebase changes made in this diff.
- [x] All automated checks and tests pass during CI.
- [x] Documentation and code comments have been added (where applicable).
- [ ] Any hacks or questionable design decisions have been highlighted in the code and in the PR.
- [ ] Does the PR require any infrastructure changes before deployment? Detail them below if so.
- [ ] Are there any other outstanding blockers or pre-requisites that must be satisfied elsewhere in order for this work to be released?
- [ ] If this is a feature PR, add this PR to the summary of the `Dev -> Prod` PR or open that PR if necessary. This helps us track the contents of production deploys.
- [ ] Are there any other required post-deployment actions? If so, detail them below **_AND_** on a `develop` to `main` PR.


### Infrastructure Changes (Optional)

<!-- Please give a short summary of the necessary infrastructure. Link to any relevant GH or Jira tickets. -->

### Blockers (Optional)

### Post Deployment Actions (Optional)

<!-- Include any post-deployment actions such as Django management commands.
If this is a `develop` to `main` PR, individual feature branch authors need to
copy their notes from the individual PR here. -->
