### PR TITLE
Bug fix: search state reset on page load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pagefind-vue",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pagefind-vue",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "vue": "^3.5.13"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagefind-vue",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "./dist/pagefind-vue.umd.js",
   "module": "./dist/pagefind-vue.es.js",

--- a/src/components/PagefindSearch.vue
+++ b/src/components/PagefindSearch.vue
@@ -633,7 +633,7 @@ async function performSearch(query: string | null, isInitialLoad: boolean = fals
       calculateTabCounts(searchMinusTab.filters)
 
       // Handle tab selection
-      if (!activeTab.value && tabs.value.length > 0) {
+      if (!activeTab.value && tabs.value.length > 0 && !isInitialLoad) {
         activeTab.value = props.defaultTab || tabs.value[0].value
       }
     } else {


### PR DESCRIPTION
There was a race condition affecting the reading of search state from the URL when this component library was used in the Tsumeb project.

1. On page load, `onMount()` reads the URL params and sets the search state variables, then calls `performSearch` at the end of its setup.
2. `performSearch()` uses the search state to get filter facet counts and results. However, if the `activeTab` state variable (a Vue `ref()`) is not yet set, then `performSearch()` sets it to the `defaultTab` if provided, otherwise the first one.
3. This by itself is enough to mess up the search state, but because we have a watcher on `activeTab`, updating it also calls `performSearch()`.

So, `performSearch()` was being called from within the initial `performSearch()` _after_ resetting the tab filter state.

I could not ever replicate this locally—perhaps it is the amount of data that causes there to be a delay between reading `activeTab` and updating it. This is just one of those issues with frameworks like Vue and React, there is a lot of async code being called in the background.

We already have the tools to fix this problem, though, since we already have a state variable for tracking whether the `performSearch()` is being called for the first time in the component lifecycle. Adding that check resolved the problem, proving it was a race condition.

## Change Summary

<!-- Please give a short summary of the changes in the diff. -->
<!-- If the code is a "work in progress" then mark the PR as draft and include 'WIP' in the title. -->
<!-- More complex diffs should contain more detailed descriptions so the reviewers can understand what is going on.

## PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Refactor/optimization
- [ ] Test Coverage
- [ ] Documentation
- [ ] Revert
- [ ] Release